### PR TITLE
Remove full-screen button when in PWA

### DIFF
--- a/src/components/ui/Footer.jsx
+++ b/src/components/ui/Footer.jsx
@@ -3,6 +3,11 @@ import screenfull from "screenfull";
 import "./Footer.css";
 import { MdFullscreen, MdFullscreenExit } from "react-icons/md";
 
+const isInStandaloneMode = () =>
+	(window.matchMedia('(display-mode: standalone)').matches)
+	|| (window.navigator.standalone)
+	|| document.referrer.includes('android-app://');
+
 export default function Footer() {
 	const [isFullscreen, setFullscreen] = useState(screenfull.isFullscreen);
 	const handleFullscreen = () => {
@@ -11,14 +16,16 @@ export default function Footer() {
 	};
 	return (
 		<>
-			<div className="quickSettings">
-				{screenfull.isEnabled &&
-					(!isFullscreen ? (
-						<MdFullscreen onClick={handleFullscreen} />
-					) : (
-						<MdFullscreenExit onClick={handleFullscreen} />
-					))}
-			</div>
+			{!isInStandaloneMode() && (
+				<div className="quickSettings">
+					{screenfull.isEnabled &&
+						(!isFullscreen ? (
+							<MdFullscreen onClick={handleFullscreen} />
+						) : (
+							<MdFullscreenExit onClick={handleFullscreen} />
+						))}
+				</div>
+			)}
 			<div id="footer">
 				Made with ❤️ by madOverGames |{" "}
 				<a href="https://github.com/madOverGames/tic-tac-toe">Github</a>


### PR DESCRIPTION
Pull Request for #11 
> Remove the full-screen button

The full-screen button now hides when the app is in PWA mode!

**Note:** If you are switching from browser to PWA mode then you'll have to reload to see changes, else you'll immediately see the changes if the app was directly opened as a PWA (like from the home screen icon, etc.)

Thanks for the opportunity!