### PR TITLE
FIX: Scrollbar Scaling Issue

### DIFF
--- a/src/components/app/GameView.css
+++ b/src/components/app/GameView.css
@@ -1,5 +1,5 @@
 #gameView {
-	width: min(95vw, 470px);
+	width: min(95vw, 85vh);
 	display: flex;
 	flex-direction: column;
 	text-align: center;

--- a/src/components/ui/Footer.css
+++ b/src/components/ui/Footer.css
@@ -4,6 +4,8 @@
 	font-weight: 500;
 	font-size: smaller;
 	text-align: center;
+	position: fixed;
+	width: 100%;
 }
 #footer a {
 	text-decoration: none;

--- a/src/components/ui/Header.css
+++ b/src/components/ui/Header.css
@@ -3,6 +3,7 @@
 	font-size: 2.2rem;
 	padding: 1rem;
 	justify-content: space-between;
+	position: fixed;
 }
 .button {
 	display: inline-flex;


### PR DESCRIPTION
Fixed scaling issue with  GameView. It will expand or shrink based on both viewport height and width. The header & Footer positions were also changed to "fixed" so it can be easily scalable on small screens and GameView can center to the screen.
![Screenshot 2022-10-08 at 10 18 19 PM](https://user-images.githubusercontent.com/23289603/194718576-0650706f-b166-436a-bf0f-d24c74f833ab.png)
![Screenshot 2022-10-08 at 10 17 03 PM](https://user-images.githubusercontent.com/23289603/194718585-b54ee256-84d3-4ec5-ae93-bd5eb752d377.png)
![Screenshot 2022-10-08 at 10 17 52 PM](https://user-images.githubusercontent.com/23289603/194718590-2db47d79-92fe-4568-97fa-eb28449943bf.png)
